### PR TITLE
Check for partially overlapping sticky ends

### DIFF
--- a/dna_functions.py
+++ b/dna_functions.py
@@ -33,7 +33,7 @@ def sum_is_sticky(seq1: Dseq, seq2: Dseq, partial: bool=False) -> bool:
             sticky_seq2 = str(reverse_complement(sticky_seq2))
     
         ovhg_len = min(len(sticky_seq1), len(sticky_seq2))
-        for i in range(1, ovhg_len):
+        for i in range(1, ovhg_len+1):
             if sticky_seq1[-i:] == sticky_seq2[:i]:
                 return True
         else:

--- a/dna_functions.py
+++ b/dna_functions.py
@@ -33,8 +33,8 @@ def sum_is_sticky(seq1: Dseq, seq2: Dseq, partial: bool=False) -> bool:
             sticky_seq2 = str(reverse_complement(sticky_seq2))
     
         ovhg_len = min(len(sticky_seq1), len(sticky_seq2))
-        for i in range(ovhg_len):
-            if sticky_seq1[-(i+1):] == sticky_seq2[:i+1]:
+        for i in range(1, ovhg_len):
+            if sticky_seq1[-i:] == sticky_seq2[:i]:
                 return True
         else:
             return False

--- a/main.py
+++ b/main.py
@@ -227,8 +227,9 @@ async def sticky_ligation(source: StickyLigationSource,
     if len(source.fragments_inverted) > 0:
         # TODO Error if the list has different order or the ids are wrong.
         # TODO check input for unique ids
+        # TODO Modify frontend to allow for partially overlapping sticky ends (partial bool parameter)
         assembly_list = get_assembly_list_from_sticky_ligation_source(dseqs, source)
-        if not assembly_list_is_valid(assembly_list, source.circularised):
+        if not assembly_list_is_valid(assembly_list, source.circularised, partial=False):
             raise HTTPException(
                 400, 'Fragments are not compatible for sticky ligation')
         output_sequence = format_sequence_genbank(perform_assembly(assembly_list, source.circularised))

--- a/test_dna_functions.py
+++ b/test_dna_functions.py
@@ -134,3 +134,11 @@ class MultiTestPartialSticky(TestPartialSticky):
 
         self.expectTrue(seq3, seq4, True)
         self.expectFalse(seq3, seq4, False)
+
+    def test_sticky_ends_max_len(self):
+        # Ensures that all possible overlapping lengths are covered
+        seq1 = Dseq("ACGT", "GTACGT", ovhg=0)
+        seq2 = Dseq("ACAACGT", "ACGT", ovhg=-3)
+
+        self.expectTrue(seq1, seq2, True)
+        self.expectFalse(seq1, seq2, False)


### PR DESCRIPTION
Related to issue #6 

This PR modifies the assembly verification step to check for partially overlapping sticky ends. It also ads unit tests for the new functionality.

Remaining TODOs:
- Modify frontend to allow user to decide whether to allow or no partially overlapping overhangs.
- Allow assembly of these overhangs