### PR TITLE
Read .ape as .gb files

### DIFF
--- a/main.py
+++ b/main.py
@@ -198,6 +198,7 @@ async def read_from_file(
         extension_dict = {
             'gbk': 'genbank',
             'gb': 'genbank',
+            'ape': 'genbank',
             'dna': 'snapgene',
             'fasta': 'fasta',
             'embl': 'embl',


### PR DESCRIPTION
Simple fix for #202:
- Parse .ape as .gb

Associated changes in frontend:
- Indicate that SYC supports .ape
- Rename "Genbank" format to "Genbank / ApE"