### PR TITLE
Gateway primer design

### DIFF
--- a/gateway.py
+++ b/gateway.py
@@ -88,6 +88,15 @@ gateway_sites_conservative = {
     for k, v in raw_gateway_sites_conservative.items()
 }
 
+# From snapgene - ask Valerie
+primer_design_attB = {
+    'attB1': 'ACAAGTTTGTACAAAAAAGCAGGCT',
+    'attB2': 'ACCACTTTGTACAAGAAAGCTGGGT',
+    'attB3': 'ACAACTTTGTATAATAAAGTTGTA',
+    'attB4': 'ACAACTTTGTATAGAAAAGTTGTA',
+    'attB5': 'ACAACTTTGTATACAAAAGTTGTA',
+}
+
 
 def gateway_overlap(seqx: _Dseqrecord, seqy: _Dseqrecord, reaction: str, greedy: bool) -> list[tuple[int, int, int]]:
     """Find gateway overlaps"""

--- a/main.py
+++ b/main.py
@@ -73,7 +73,12 @@ import ncbi_requests
 import os
 from record_stub_route import RecordStubRoute
 from starlette.responses import RedirectResponse
-from primer_design import homologous_recombination_primers, gibson_assembly_primers, simple_pair_primers
+from primer_design import (
+    homologous_recombination_primers,
+    gibson_assembly_primers,
+    simple_pair_primers,
+    gateway_attB_primers,
+)
 import asyncio
 import re
 import warnings
@@ -1171,10 +1176,10 @@ async def gateway(
     return resp
 
 
-@router.post(
-    '/primer_design/homologous_recombination',
-    response_model=create_model('HomologousRecombinationPrimerDesignResponse', primers=(list[PrimerModel], ...)),
-)
+PrimerDesignResponse = create_model('PrimerDesignResponse', primers=(list[PrimerModel], ...))
+
+
+@router.post('/primer_design/homologous_recombination', response_model=PrimerDesignResponse)
 async def primer_design_homologous_recombination(
     pcr_template: PrimerDesignQuery,
     homologous_recombination_target: PrimerDesignQuery,
@@ -1223,21 +1228,7 @@ async def primer_design_homologous_recombination(
     return {'primers': [forward_primer, reverse_primer]}
 
 
-# A primer design endpoint for Gibson assembly
-# This is how the request data will look like from javascript code:
-# const requestData = {
-#       queries: templateEntities.map((e, index) => ({
-#         sequence: e,
-#         location: selectedRegion2SequenceLocation(amplifyRegions[index]),
-#         orientation: fragmentOrientations[index],
-#       })),
-#     };
-
-
-@router.post(
-    '/primer_design/gibson_assembly',
-    response_model=create_model('GibsonAssemblyPrimerDesignResponse', primers=(list[PrimerModel], ...)),
-)
+@router.post('/primer_design/gibson_assembly', response_model=PrimerDesignResponse)
 async def primer_design_gibson_assembly(
     pcr_templates: list[PrimerDesignQuery],
     spacers: list[str] | None = Body(
@@ -1277,11 +1268,7 @@ async def primer_design_gibson_assembly(
     return {'primers': primers}
 
 
-@router.post(
-    '/primer_design/simple_pair',
-    response_model=create_model('SimplePairPrimerDesignResponse', primers=(list[PrimerModel], ...)),
-    summary='Design primers for PCR, you can also include restriction enzyme sites with filler bases.',
-)
+@router.post('/primer_design/simple_pair', response_model=PrimerDesignResponse)
 async def primer_design_simple_pair(
     pcr_template: PrimerDesignQuery,
     spacers: list[str] | None = Body(
@@ -1372,6 +1359,41 @@ if PLANNOTATE_URL is not None:
         return {'sources': [source], 'sequences': [format_sequence_genbank(seqr, source.output_name)]}
 
 
+@router.post('/primer_design/gateway_attB', response_model=PrimerDesignResponse)
+async def primer_design_gateway_attB(
+    template: PrimerDesignQuery,
+    left_site: str = Query(..., description='The left attB site to recombine.', regex=r'^attB[1-5]$'),
+    right_site: str = Query(..., description='The right attB site to recombine.', regex=r'^attB[1-5]$'),
+    spacers: list[str] | None = Body(None, description='Spacers to add between the attB site and the primer.'),
+    filler_bases: str = Query(
+        'GGGG',
+        description='These bases are added to the 5\' end of the primer to ensure proper restriction enzyme digestion.',
+    ),
+    minimal_hybridization_length: int = Query(
+        ..., description='The minimal length of the hybridization region in bps.'
+    ),
+    target_tm: float = Query(
+        ..., description='The desired melting temperature for the hybridization part of the primer.'
+    ),
+):
+    """Design primers for Gateway attB"""
+    dseqr = read_dsrecord_from_json(template.sequence)
+    location = template.location.to_biopython_location(dseqr.circular, len(dseqr))
+    template = location.extract(dseqr)
+    if not template.forward_orientation:
+        template = template.reverse_complement()
+    template.name = dseqr.name
+    template.id = dseqr.id
+    try:
+        primers = gateway_attB_primers(
+            template, minimal_hybridization_length, target_tm, (left_site, right_site), spacers, filler_bases
+        )
+    except ValueError as e:
+        raise HTTPException(400, *e.args)
+
+    return {'primers': primers}
+
+
 @router.post(
     '/validate',
     summary='Validate a cloning strategy',
@@ -1391,6 +1413,20 @@ async def rename_sequence(
     """Rename a sequence"""
     dseqr = read_dsrecord_from_json(sequence)
     return format_sequence_genbank(dseqr, name)
+
+
+@router.post('/annotation/get_gateway_sites', response_model=dict[str, list[str]])
+async def get_gateway_sites(
+    sequence: TextFileSequence, greedy: bool = Query(False, description='Whether to use the greedy algorithm.')
+) -> dict[str, list[str]]:
+    """
+    Get a dictionary with the names of the gateway sites present in the sequence and their locations as strings.
+    """
+    dseqr = read_dsrecord_from_json(sequence)
+    sites_dict = find_gateway_sites(dseqr, greedy)
+    for site in sites_dict:
+        sites_dict[site] = [str(loc) for loc in sites_dict[site]]
+    return sites_dict
 
 
 if not SERVE_FRONTEND:

--- a/main.py
+++ b/main.py
@@ -77,7 +77,6 @@ from primer_design import (
     homologous_recombination_primers,
     gibson_assembly_primers,
     simple_pair_primers,
-    gateway_attB_primers,
 )
 import asyncio
 import re
@@ -1359,39 +1358,39 @@ if PLANNOTATE_URL is not None:
         return {'sources': [source], 'sequences': [format_sequence_genbank(seqr, source.output_name)]}
 
 
-@router.post('/primer_design/gateway_attB', response_model=PrimerDesignResponse)
-async def primer_design_gateway_attB(
-    template: PrimerDesignQuery,
-    left_site: str = Query(..., description='The left attB site to recombine.', regex=r'^attB[1-5]$'),
-    right_site: str = Query(..., description='The right attB site to recombine.', regex=r'^attB[1-5]$'),
-    spacers: list[str] | None = Body(None, description='Spacers to add between the attB site and the primer.'),
-    filler_bases: str = Query(
-        'GGGG',
-        description='These bases are added to the 5\' end of the primer to ensure proper restriction enzyme digestion.',
-    ),
-    minimal_hybridization_length: int = Query(
-        ..., description='The minimal length of the hybridization region in bps.'
-    ),
-    target_tm: float = Query(
-        ..., description='The desired melting temperature for the hybridization part of the primer.'
-    ),
-):
-    """Design primers for Gateway attB"""
-    dseqr = read_dsrecord_from_json(template.sequence)
-    location = template.location.to_biopython_location(dseqr.circular, len(dseqr))
-    template = location.extract(dseqr)
-    if not template.forward_orientation:
-        template = template.reverse_complement()
-    template.name = dseqr.name
-    template.id = dseqr.id
-    try:
-        primers = gateway_attB_primers(
-            template, minimal_hybridization_length, target_tm, (left_site, right_site), spacers, filler_bases
-        )
-    except ValueError as e:
-        raise HTTPException(400, *e.args)
+# @router.post('/primer_design/gateway_attB', response_model=PrimerDesignResponse)
+# async def primer_design_gateway_attB(
+#     template: PrimerDesignQuery,
+#     left_site: str = Query(..., description='The left attB site to recombine.', regex=r'^attB[1-5]$'),
+#     right_site: str = Query(..., description='The right attB site to recombine.', regex=r'^attB[1-5]$'),
+#     spacers: list[str] | None = Body(None, description='Spacers to add between the attB site and the primer.'),
+#     filler_bases: str = Query(
+#         'GGGG',
+#         description='These bases are added to the 5\' end of the primer to ensure proper restriction enzyme digestion.',
+#     ),
+#     minimal_hybridization_length: int = Query(
+#         ..., description='The minimal length of the hybridization region in bps.'
+#     ),
+#     target_tm: float = Query(
+#         ..., description='The desired melting temperature for the hybridization part of the primer.'
+#     ),
+# ):
+#     """Design primers for Gateway attB"""
+#     dseqr = read_dsrecord_from_json(template.sequence)
+#     location = template.location.to_biopython_location(dseqr.circular, len(dseqr))
+#     template = location.extract(dseqr)
+#     if not template.forward_orientation:
+#         template = template.reverse_complement()
+#     template.name = dseqr.name
+#     template.id = dseqr.id
+#     try:
+#         primers = gateway_attB_primers(
+#             template, minimal_hybridization_length, target_tm, (left_site, right_site), spacers, filler_bases
+#         )
+#     except ValueError as e:
+#         raise HTTPException(400, *e.args)
 
-    return {'primers': primers}
+#     return {'primers': primers}
 
 
 @router.post(

--- a/primer_design.py
+++ b/primer_design.py
@@ -7,6 +7,7 @@ from pydantic_models import PrimerModel
 from Bio.Seq import reverse_complement
 from Bio.Restriction.Restriction import RestrictionType
 from Bio.Data.IUPACData import ambiguous_dna_values as _ambiguous_dna_values
+from gateway import primer_design_attB
 
 ambiguous_dna_values = _ambiguous_dna_values.copy()
 # Remove acgt
@@ -163,4 +164,41 @@ def simple_pair_primers(
     return (
         PrimerModel(id=0, name=fwd_primer_name, sequence=str(fwd_primer_seq)),
         PrimerModel(id=0, name=rvs_primer_name, sequence=str(rvs_primer_seq)),
+    )
+
+
+def gateway_attB_primers(
+    template: Dseqrecord,
+    minimal_hybridization_length: int,
+    target_tm: float,
+    sites: tuple[str, str],
+    spacers: tuple[str, str],
+    filler_bases: str = 'GGGG',
+) -> tuple[PrimerModel, PrimerModel]:
+    if spacers is None:
+        spacers = ['', '']
+
+    if len(spacers) != 2:
+        raise ValueError("The 'spacers' list must contain exactly two elements.")
+
+    if sites[0] not in primer_design_attB or sites[1] not in primer_design_attB:
+        raise ValueError('Invalid attB site.')
+
+    amplicon = primer_design(template, limit=minimal_hybridization_length, target_tm=target_tm)
+    fwd_primer, rvs_primer = amplicon.primers()
+
+    if fwd_primer is None or rvs_primer is None:
+        raise ValueError('Primers could not be designed, try changing settings.')
+
+    template_name = template.name if template.name != 'name' else f'seq_{template.id}'
+
+    left_site = primer_design_attB[sites[0]]
+    right_site = primer_design_attB[sites[1]]
+
+    fwd_primer_seq = filler_bases + left_site + spacers[0] + fwd_primer.seq
+    rvs_primer_seq = filler_bases + right_site + reverse_complement(spacers[1]) + rvs_primer.seq
+
+    return (
+        PrimerModel(id=0, name=f'{template_name}_{sites[0]}_fwd', sequence=str(fwd_primer_seq)),
+        PrimerModel(id=0, name=f'{template_name}_{sites[1]}_rvs', sequence=str(rvs_primer_seq)),
     )

--- a/primer_design.py
+++ b/primer_design.py
@@ -7,7 +7,6 @@ from pydantic_models import PrimerModel
 from Bio.Seq import reverse_complement
 from Bio.Restriction.Restriction import RestrictionType
 from Bio.Data.IUPACData import ambiguous_dna_values as _ambiguous_dna_values
-from gateway import primer_design_attB
 
 ambiguous_dna_values = _ambiguous_dna_values.copy()
 # Remove acgt
@@ -167,38 +166,38 @@ def simple_pair_primers(
     )
 
 
-def gateway_attB_primers(
-    template: Dseqrecord,
-    minimal_hybridization_length: int,
-    target_tm: float,
-    sites: tuple[str, str],
-    spacers: tuple[str, str],
-    filler_bases: str = 'GGGG',
-) -> tuple[PrimerModel, PrimerModel]:
-    if spacers is None:
-        spacers = ['', '']
+# def gateway_attB_primers(
+#     template: Dseqrecord,
+#     minimal_hybridization_length: int,
+#     target_tm: float,
+#     sites: tuple[str, str],
+#     spacers: tuple[str, str],
+#     filler_bases: str = 'GGGG',
+# ) -> tuple[PrimerModel, PrimerModel]:
+#     if spacers is None:
+#         spacers = ['', '']
 
-    if len(spacers) != 2:
-        raise ValueError("The 'spacers' list must contain exactly two elements.")
+#     if len(spacers) != 2:
+#         raise ValueError("The 'spacers' list must contain exactly two elements.")
 
-    if sites[0] not in primer_design_attB or sites[1] not in primer_design_attB:
-        raise ValueError('Invalid attB site.')
+#     if sites[0] not in primer_design_attB or sites[1] not in primer_design_attB:
+#         raise ValueError('Invalid attB site.')
 
-    amplicon = primer_design(template, limit=minimal_hybridization_length, target_tm=target_tm)
-    fwd_primer, rvs_primer = amplicon.primers()
+#     amplicon = primer_design(template, limit=minimal_hybridization_length, target_tm=target_tm)
+#     fwd_primer, rvs_primer = amplicon.primers()
 
-    if fwd_primer is None or rvs_primer is None:
-        raise ValueError('Primers could not be designed, try changing settings.')
+#     if fwd_primer is None or rvs_primer is None:
+#         raise ValueError('Primers could not be designed, try changing settings.')
 
-    template_name = template.name if template.name != 'name' else f'seq_{template.id}'
+#     template_name = template.name if template.name != 'name' else f'seq_{template.id}'
 
-    left_site = primer_design_attB[sites[0]]
-    right_site = primer_design_attB[sites[1]]
+#     left_site = primer_design_attB[sites[0]]
+#     right_site = primer_design_attB[sites[1]]
 
-    fwd_primer_seq = filler_bases + left_site + spacers[0] + fwd_primer.seq
-    rvs_primer_seq = filler_bases + right_site + reverse_complement(spacers[1]) + rvs_primer.seq
+#     fwd_primer_seq = filler_bases + left_site + spacers[0] + fwd_primer.seq
+#     rvs_primer_seq = filler_bases + right_site + reverse_complement(spacers[1]) + rvs_primer.seq
 
-    return (
-        PrimerModel(id=0, name=f'{template_name}_{sites[0]}_fwd', sequence=str(fwd_primer_seq)),
-        PrimerModel(id=0, name=f'{template_name}_{sites[1]}_rvs', sequence=str(rvs_primer_seq)),
-    )
+#     return (
+#         PrimerModel(id=0, name=f'{template_name}_{sites[0]}_fwd', sequence=str(fwd_primer_seq)),
+#         PrimerModel(id=0, name=f'{template_name}_{sites[1]}_rvs', sequence=str(rvs_primer_seq)),
+#     )

--- a/test_endpoints.py
+++ b/test_endpoints.py
@@ -2687,5 +2687,32 @@ class PlannotateTest(unittest.TestCase):
         self.assertEqual(e.code, 400)
 
 
+class AnnotationTest(unittest.TestCase):
+
+    attB1 = 'ACAACTTTGTACAAAAAAGCAGAAG'
+    attB2 = 'ACAACTTTGTACAAGAAAGCTGGGC'
+    greedy_attP1 = 'CAAATAATGATTTTATTTTGACTGATAGTGACCTGTTCGTTGCAACAAATTGATAAGCAATGCTTTTTTATAATGCCAACTTTGTACAAAAAAGCTGAACGAGAAACGTAAAATGATATAAATATCAATATATTAAATTAGATTTTGCATAAAAAACAGACTACATAATACTGTAAAACACAACATATCCAGTCA'
+
+    def test_get_gateway_sites(self):
+        seq = Dseqrecord('aaa' + self.attB1 + 'ccc' + self.attB2 + 'ccc' + self.greedy_attP1)
+        response = client.post('/annotation/get_gateway_sites', json=format_sequence_genbank(seq).model_dump())
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIn('attB1', payload)
+        self.assertIn('attB2', payload)
+        self.assertNotIn('attP1', payload)
+
+        response = client.post(
+            '/annotation/get_gateway_sites',
+            json=format_sequence_genbank(seq).model_dump(),
+            params={'greedy': True},
+        )
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIn('attB1', payload)
+        self.assertIn('attB2', payload)
+        self.assertIn('attP1', payload)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_primer_design.py
+++ b/test_primer_design.py
@@ -1,4 +1,10 @@
-from primer_design import homologous_recombination_primers, gibson_assembly_primers, simple_pair_primers
+from primer_design import (
+    homologous_recombination_primers,
+    gibson_assembly_primers,
+    simple_pair_primers,
+    gateway_attB_primers,
+    primer_design_attB,
+)
 from Bio.SeqFeature import SimpleLocation, SeqFeature
 from unittest import TestCase
 from pydna.dseqrecord import Dseqrecord
@@ -511,3 +517,27 @@ class TestSimplePairPrimers(TestCase):
         # Check that primers are correct
         self.assertTrue(fwd.sequence.startswith('ATGCA'))
         self.assertTrue(rvs.sequence.startswith('GTCAT'))
+
+
+class TestGatewayAttBPrimers(TestCase):
+    def test_normal_examples(self):
+        """
+        Test the gateway_attB_primers function.
+        """
+        template = Dseqrecord('ATGCAAACAGTGAACAGATGGAGACAATAATGATGGATGAC')
+        template.id = '0'
+        minimal_hybridization_length = 10
+        target_tm = 55
+        left_site = 'attB1'
+        right_site = 'attB5'
+        spacers = None
+
+        primers = gateway_attB_primers(
+            template, minimal_hybridization_length, target_tm, (left_site, right_site), spacers
+        )
+
+        self.assertEqual(len(primers), 2)
+        self.assertEqual(primers[0].name, 'seq_0_attB1_fwd')
+        self.assertEqual(primers[1].name, 'seq_0_attB5_rvs')
+        self.assertTrue(primers[0].sequence.startswith('GGGG' + primer_design_attB['attB1']))
+        self.assertTrue(primers[1].sequence.startswith('GGGG' + primer_design_attB['attB5']))

--- a/test_primer_design.py
+++ b/test_primer_design.py
@@ -2,8 +2,6 @@ from primer_design import (
     homologous_recombination_primers,
     gibson_assembly_primers,
     simple_pair_primers,
-    gateway_attB_primers,
-    primer_design_attB,
 )
 from Bio.SeqFeature import SimpleLocation, SeqFeature
 from unittest import TestCase
@@ -519,25 +517,25 @@ class TestSimplePairPrimers(TestCase):
         self.assertTrue(rvs.sequence.startswith('GTCAT'))
 
 
-class TestGatewayAttBPrimers(TestCase):
-    def test_normal_examples(self):
-        """
-        Test the gateway_attB_primers function.
-        """
-        template = Dseqrecord('ATGCAAACAGTGAACAGATGGAGACAATAATGATGGATGAC')
-        template.id = '0'
-        minimal_hybridization_length = 10
-        target_tm = 55
-        left_site = 'attB1'
-        right_site = 'attB5'
-        spacers = None
+# class TestGatewayAttBPrimers(TestCase):
+#     def test_normal_examples(self):
+#         """
+#         Test the gateway_attB_primers function.
+#         """
+#         template = Dseqrecord('ATGCAAACAGTGAACAGATGGAGACAATAATGATGGATGAC')
+#         template.id = '0'
+#         minimal_hybridization_length = 10
+#         target_tm = 55
+#         left_site = 'attB1'
+#         right_site = 'attB5'
+#         spacers = None
 
-        primers = gateway_attB_primers(
-            template, minimal_hybridization_length, target_tm, (left_site, right_site), spacers
-        )
+#         primers = gateway_attB_primers(
+#             template, minimal_hybridization_length, target_tm, (left_site, right_site), spacers
+#         )
 
-        self.assertEqual(len(primers), 2)
-        self.assertEqual(primers[0].name, 'seq_0_attB1_fwd')
-        self.assertEqual(primers[1].name, 'seq_0_attB5_rvs')
-        self.assertTrue(primers[0].sequence.startswith('GGGG' + primer_design_attB['attB1']))
-        self.assertTrue(primers[1].sequence.startswith('GGGG' + primer_design_attB['attB5']))
+#         self.assertEqual(len(primers), 2)
+#         self.assertEqual(primers[0].name, 'seq_0_attB1_fwd')
+#         self.assertEqual(primers[1].name, 'seq_0_attB5_rvs')
+#         self.assertTrue(primers[0].sequence.startswith('GGGG' + primer_design_attB['attB1']))
+#         self.assertTrue(primers[1].sequence.startswith('GGGG' + primer_design_attB['attB5']))


### PR DESCRIPTION
The only real change is the `get_gateway_sites`

The rest is an implementation that I think I will remove eventually. I think it makes more sense to adhere to the recommended InvitroGen primer design, and don't suggest anything for other plasmids. The primer design is useful here to make the proteins in frame with the gateway standard.